### PR TITLE
feat: 예외처리 방식 일관된 응답을 보내도록 수정

### DIFF
--- a/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/CustomException.java
+++ b/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/CustomException.java
@@ -1,0 +1,19 @@
+package kr.ac.kookmin.wink.planlist.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(Throwable cause) {
+        this(DefaultErrorCode.DEFAULT, cause);
+    }
+}

--- a/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/DefaultErrorCode.java
+++ b/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/DefaultErrorCode.java
@@ -1,0 +1,17 @@
+package kr.ac.kookmin.wink.planlist.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum DefaultErrorCode implements ErrorCode {
+    DEFAULT("응답 처리 중, 예외가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    DefaultErrorCode(String message, HttpStatus httpStatus) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/ErrorCode.java
+++ b/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package kr.ac.kookmin.wink.planlist.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String name();
+    String getMessage();
+    HttpStatus getHttpStatus();
+}

--- a/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/ErrorResponseDTO.java
+++ b/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/ErrorResponseDTO.java
@@ -1,0 +1,28 @@
+package kr.ac.kookmin.wink.planlist.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class ErrorResponseDTO {
+    private String code;
+    private String message;
+    private Integer status;
+    private Instant timestamp;
+
+    public static ErrorResponseDTO create(ErrorCode errorCode, Instant timestamp) {
+        return ErrorResponseDTO.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .status(errorCode.getHttpStatus().value())
+                .timestamp(timestamp)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/ac/kookmin/wink/planlist/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package kr.ac.kookmin.wink.planlist.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponseDTO> handleCustomException(CustomException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        ErrorResponseDTO errorResponseDTO = ErrorResponseDTO.create(errorCode, Instant.now());
+        HttpStatus httpStatus = errorCode.getHttpStatus();
+
+        return new ResponseEntity<>(errorResponseDTO, httpStatus);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21 

## 📝작업 내용

> GlobalExceptionHandler를 구현하여, 예외가 발생했을 때 클라이언트에게 예외 정보를 일관되게 보낼 수 있도록 수정하였습니다.

### 참고자료

> https://velog.io/@letsdev/Spring-%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%AC-%EC%89%BD%EA%B2%8C-%EA%B4%80%EC%8B%AC%EC%82%AC-%EB%82%98%EB%88%84%EA%B8%B0-Global-Exception-HandlerController-Advice

## 💬리뷰 요구사항(선택)
